### PR TITLE
Add gh cli

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag cicirello/pyaction:$(date +%s)
+      run: docker build . --file Dockerfile

--- a/.github/workflows/docker-manual-publish.yml
+++ b/.github/workflows/docker-manual-publish.yml
@@ -61,7 +61,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v6,linux/arm/v7
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: org.opencontainers.image.version=${{ steps.prep.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v6,linux/arm/v7
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: org.opencontainers.image.version=${{ steps.prep.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,28 @@
-# Copyright (c) 2020 Vincent A. Cicirello
+# Copyright (c) 2020-2021 Vincent A. Cicirello
 # https://www.cicirello.org
 # Source repository: https://github.com/cicirello/pyaction
 # Source licensed under the MIT License: https://github.com/cicirello/pyaction/blob/master/LICENSE
-FROM alpine:3.14.0
+
+# Base image is Python 3 Slim
+FROM python:3-slim
+
 LABEL maintainer="development@cicirello.org" \
     org.opencontainers.image.description="A base Docker image for Github Actions implemented in Python" \
     org.opencontainers.image.authors="Vincent A Cicirello, development@cicirello.org, https://www.cicirello.org/" \
     org.opencontainers.image.source="https://github.com/cicirello/pyaction" \
     org.opencontainers.image.title="pyaction" 
-RUN apk --no-cache add \
-    git \
-    python3 
+
+# Install git and the GitHub CLI (gh), and their dependencies.
+# Note that curl and gpg are installed here because they are
+# required for the installation of gh.
+RUN true \
+    && apt-get update && apt-get install -y \
+       curl \
+       gpg \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y \
+       gh \
+	   git \
+    && rm -rf /var/lib/apt/lists/* \
+    && true


### PR DESCRIPTION
## Summary
Added GitHub CLI (gh) to image. To do this, the base image had to be changed to one supported by gh.  So base is not python:3-slim, rather than Alpine. This is a Debian distro, so this is possibly a breaking change. Also had to remove a couple supported archs so that we now only support those archs that are also supported by gh.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
