### PR TITLE
Add arm/v6 architecture

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: org.opencontainers.image.version=${{ steps.prep.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ __Version 4.0.0 and Newer__: pyaction supports the following
 platforms:
 * linux/386
 * linux/amd64
-* linux/arm/v7
 * linux/arm64
+* linux/arm/v7
+* linux/arm/v6
 
 __Version 3.14.0 and Earlier__: earlier releases supported the
 above as well as the following:
-* linux/arm/v6
 * linux/ppc64le
 * linux/s390x 
 


### PR DESCRIPTION
## Summary
Add arm/v6 architecture. The GitHub CLI appears to now be available for arm/v6. Updated workflow to to build the relevant image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
